### PR TITLE
fix(message-signing): use varuint length encoding

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@zondax/ledger-blockstack",
-  "version": "0.22.4",
+  "version": "0.22.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zondax/ledger-blockstack",
-      "version": "0.22.4",
+      "version": "0.22.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@ledgerhq/hw-transport": "^5.51.1",
-        "@stacks/transactions": "^4.1.0"
+        "@stacks/transactions": "^4.1.0",
+        "varuint-bitcoin": "^1.1.2"
       },
       "devDependencies": {
         "@babel/cli": "^7.12.10",
@@ -5368,6 +5369,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -9377,6 +9386,14 @@
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
+      }
+    },
+    "varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
       }
     },
     "webidl-conversions": {

--- a/js/package.json
+++ b/js/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@ledgerhq/hw-transport": "^5.51.1",
-    "@stacks/transactions": "^4.1.0"
+    "@stacks/transactions": "^4.1.0",
+    "varuint-bitcoin": "^1.1.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -29,6 +29,7 @@ import {
     PKLEN,
     processErrorResponse,
 } from './common';
+import {encode} from 'varuint-bitcoin';
 
 import type { AddressVersion } from '@stacks/transactions';
 
@@ -249,9 +250,9 @@ export default class BlockstackApp {
     }
 
     async sign_msg(path: string, message: string) {
-        const len = message.length
-        const stacks_message = "\x17Stacks Signed Message:\n" + `${len}` + message
-        const blob = Buffer.from(stacks_message)
+        const len = encode(message.length);
+        const stacks_message = "\x17Stacks Signed Message:\n"
+        const blob = Buffer.concat([Buffer.from(stacks_message), len, Buffer.from(message)]);
         const ins = INS.SIGN_SECP256K1
         return this.signGetChunks(path, blob).then(chunks => {
             return this.signSendChunk(1, chunks.length, chunks[0], ins).then(async response => {


### PR DESCRIPTION
Related https://github.com/Zondax/ledger-stacks/issues/123 

This is just the change needed in the js lib.